### PR TITLE
89 fix careers

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -16,132 +16,104 @@ function checkAndUpdateHeader(e) {
     }
 }
 
-function mapFields(jobs){
-    // mapping from import.io fields to human readable fields
-    var fields = {
-        Department: 'reqrowclick_value_1',
-        State: 'reqrowclick_value_3',
-        City: 'reqrowclick_value_2',
-        Position: {
-            text: 'reqrowclick_link/_text',
-            href: 'reqrowclick_link'
-        }
-    };
-
-    var formattedJobs = jobs.slice(0);
-
-    formattedJobs.forEach(function(job){
-        job.Department = job[fields.Department];
-        job.State = job[fields.State];
-        job.City = job[fields.City];
-        job.Position = {
-            text: job[fields.Position.text],
-            href: job[fields.Position.href]
-        };
-    });
-
-    return formattedJobs;
-}
-
 function initJobs() {
     var cont = document.getElementById('jobs');
     if (cont) {
-        var url = "https://api.import.io/store/connector/_magic?_apikey=31b1810b9a5a40fc8baec04885b84ccd06d16354a8c722b6d29903d85ed090f8192934726007204b3d72cc88c00a5a2898cef0b3da8a5fe6a041fd41ae036b2b3dcfbfa5443906e6990b8cbe27d104fa&url=http://atsid.hrmdirect.com/employment/job-openings.php?search=true";
+        var url = "https://235g4vs0dj.execute-api.us-west-2.amazonaws.com/prod/hrm-direct-jobs";
         var request = new Http.Get(url, true);
         request.start().then(function (response) {
             cont.innerHTML = "";
 
-            var responseJson = JSON.parse(response);
-            var table = responseJson.tables[0];
-            if (table.results && table.results.length) {
-                var jobs = mapFields(table.results);
-                jobs.sort(function (a, b) {
-                    if (a.Department > b.Department) {
-                        return -1;
-                    }
-                    if (a.Department < b.Department) {
-                        return 1;
-                    }
-                    if (a.State > b.State) {
-                        return 1;
-                    }
-                    if (a.State < b.State) {
-                        return -1;
-                    }
-                    if (a.City > b.City) {
-                        return 1;
-                    }
-                    if (a.City < b.City) {
-                        return -1;
-                    }
-                    if (a.Position.text > b.Position.text) {
-                        return 1;
-                    }
-                    if (a.Position.text < b.Position.text) {
-                        return -1;
-                    }
-                    return 0;
-                });
+            var jobs = response;
 
-                var html = "";
-                var departments = {};
-                var job;
-                var tpl;
-
-
-                for (var i = 0; i < jobs.length; i++) {
-                    job = jobs[i];
-                    if (!departments[job.Department]) {
-                        departments[job.Department] = {
-                            department: job.Department,
-                            html: '<div class="jobs__department" id="' + job.Department.replace(' ', '') + '"><div class="jobs__list">'
-                        };
-                    }
-                    tpl = '<div class="jobs__item">' +
-                    '<div class="jobs__item__location">' + job.City + ', ' + job.State + '</div>' +
-                    '<div class="jobs__item__position"><a href="' + job.Position.href + '" target="_blank">' + job.Position.text + '</a></div>' +
-                    '</div>'
-                    departments[job.Department].html += tpl;
+            jobs.sort(function (a, b) {
+                if (a.department > b.department) {
+                    return -1;
                 }
-                var tabs = '<div class="jobs__tabs">';
-                for (var prop in departments) {
-                    tabs += '<div class="jobs__tabs__tab" data-tab="' + departments[prop].department.replace(' ', '') + '">' + departments[prop].department + '</div>'
-                    html += (departments[prop].html + "</div></div>");
+                if (a.department < b.department) {
+                    return 1;
                 }
-                tabs += "</div>"
-                tabs += html;
-
-                cont.innerHTML = tabs;
-
-                var tabEls = cont.querySelectorAll('.jobs__tabs__tab');
-                var tabContainers = cont.querySelectorAll('.jobs__deparment');
-                var selectedTabEl, selectedContainerEl;
-
-                function setupTab(tabEl, targetEl) {
-                    tabEl.addEventListener('click', function (e) {
-                        if (tabEl != selectedTabEl) {
-                            classie.add(tabEl, 'active');
-                            classie.remove(selectedTabEl, 'active');
-                            classie.add(targetEl, 'active');
-                            classie.remove(selectedContainerEl, 'active');
-                            selectedContainerEl = targetEl;
-                            selectedTabEl = tabEl;
-                        }
-                    });
+                if (a.state > b.state) {
+                    return 1;
                 }
+                if (a.state < b.state) {
+                    return -1;
+                }
+                if (a.city > b.city) {
+                    return 1;
+                }
+                if (a.city < b.city) {
+                    return -1;
+                }
+                if (a.title > b.title) {
+                    return 1;
+                }
+                if (a.title < b.title) {
+                    return -1;
+                }
+                return 0;
+            });
 
-                for (i = 0; i < tabEls.length; i++) {
-                    var tabEl = tabEls[i];
-                    var targetEl = document.getElementById(tabEl.getAttribute('data-tab'));
-                    // make first tab active
-                    if (i == 0) {
+            var html = "";
+            var departments = {};
+            var job;
+            var tpl;
+
+            console.log(jobs);
+
+            for (var i = 0; i < jobs.length; i++) {
+                job = jobs[i];
+                if (!departments[job.department]) {
+                    departments[job.department] = {
+                        department: job.department,
+                        html: '<div class="jobs__department" id="' + job.department.replace(' ', '') + '"><div class="jobs__list">'
+                    };
+                }
+                tpl = '<div class="jobs__item">' +
+                '<div class="jobs__item__location">' + job.city + ', ' + job.state + '</div>' +
+                '<div class="jobs__item__position"><a href="' + job.href + '" target="_blank">' + job.title + '</a></div>' +
+                '</div>'
+                departments[job.department].html += tpl;
+            }
+            var tabs = '<div class="jobs__tabs">';
+            
+            for (var prop in departments) {
+                tabs += '<div class="jobs__tabs__tab" data-tab="' + departments[prop].department.replace(' ', '') + '">' + departments[prop].department + '</div>'
+                html += (departments[prop].html + "</div></div>");
+            }
+            tabs += "</div>"
+            tabs += html;
+
+            cont.innerHTML = tabs;
+
+            var tabEls = cont.querySelectorAll('.jobs__tabs__tab');
+            var tabContainers = cont.querySelectorAll('.jobs__deparment');
+            var selectedTabEl, selectedContainerEl;
+
+            function setupTab(tabEl, targetEl) {
+                tabEl.addEventListener('click', function (e) {
+                    if (tabEl != selectedTabEl) {
                         classie.add(tabEl, 'active');
+                        classie.remove(selectedTabEl, 'active');
                         classie.add(targetEl, 'active');
-                        selectedTabEl = tabEl;
+                        classie.remove(selectedContainerEl, 'active');
                         selectedContainerEl = targetEl;
+                        selectedTabEl = tabEl;
                     }
-                    setupTab(tabEl, targetEl);
+                });
+            }
+
+            for (i = 0; i < tabEls.length; i++) {
+                var tabEl = tabEls[i];
+                var targetEl = document.getElementById(tabEl.getAttribute('data-tab'));
+                // make first tab active
+                if (i == 0) {
+                    classie.add(tabEl, 'active');
+                    classie.add(targetEl, 'active');
+                    selectedTabEl = tabEl;
+                    selectedContainerEl = targetEl;
                 }
+                setupTab(tabEl, targetEl);
             }
         });
     }}

--- a/lambda/jobs.js
+++ b/lambda/jobs.js
@@ -1,0 +1,104 @@
+'use strict';
+//AWS lambda function to retrieve the HRM Direct jobs site and parse it into usable JSON.
+//This exists because we've tried Kimono (shut down) and import.io, and they weren't reliable.
+const http = require('http');
+const baseUrl = 'http://atsid.hrmdirect.com/employment/';
+const searchUrl = baseUrl + 'job-openings.php?search=true';
+
+const fields = ['title', 'href', 'department', 'city', 'state'];
+const titlePattern = /<td id='posTitle'[\w\s="]*>.*>([\w\s\/]*)<\/td>/g;
+const linkPattern = /<td id='posTitle'[\w\s="]*><a href="(.*)">[\w\s\/]*<\/td>/g;
+const departmentPattern = /<td id='departments'[\w\s="]*>([\w\s\/]*)<\/td>/g;
+const cityPattern = /<td id='cities'[\w\s="]*>([\w\s\/]*)<\/td>/g;
+const statePattern = /<td id='state'[\w\s="]*>([\w\s\/]*)<\/td>/g;
+
+function extractRows(pattern, text) {
+    let rows = [];
+    let reg = new RegExp(pattern);
+    let match;
+    while (match = reg.exec(text)) {
+        let value;
+        if (match[1]) {
+            value = match[1];
+        } else {
+            value = match[0];
+        }
+        rows.push(value.trim());
+    }
+    return rows;
+}
+
+//extracts all the arrays of table row values
+//this is a weird data structure, because the number of outer array entries is the number of fields (5), and the inner arrays are all length === open reqs
+function extractTuple(patterns, text) {
+
+    let tuple = [];
+
+    //TODO: should validate that each is exactly the same length
+    patterns.forEach((pattern) => {
+        let rows = extractRows(pattern, text);
+        tuple.push(rows);
+    });
+
+    return tuple;
+}
+
+//turn the tuple into an array of objects, using the prop names
+//array order of the tuple must match the props order!
+function objectify(tuple, props) {
+
+    let arr = [];
+    let length = tuple[0].length; //how many rows (job reqs) have we harvested?
+
+    //create a bunch of empty objects to start with
+    for (let i = 0; i < length; i++) {
+        arr.push({});
+    }
+
+    //now fill in the props on each by "unwinding" the tuple rows
+    for (let i = 0; i < props.length; i++) {
+        let rowsOfField = tuple[i];
+        for (let j = 0; j < length; j++) {
+            arr[j][props[i]] = rowsOfField[j];
+        }
+    }
+
+    return arr;
+}
+
+exports.handler = (event, context, callback) => {
+    const req = http.get(searchUrl, (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', () => {
+
+            console.log('Successfully processed HTTPS response');
+
+            let tuple = extractTuple([
+                titlePattern,
+                linkPattern,
+                departmentPattern,
+                cityPattern,
+                statePattern
+            ], body);
+
+            console.log(tuple);
+
+            let results = objectify(tuple, fields);
+
+            //correct the job URL
+            results.forEach((job) => {
+                job.href = baseUrl + job.href;
+            });
+
+            console.log(results);
+
+            callback(null, results);
+        });
+    });
+
+    req.on('error', callback);
+    req.end();
+
+};

--- a/lambda/run-lambda.js
+++ b/lambda/run-lambda.js
@@ -1,0 +1,8 @@
+'use strict';
+//Execute lambda handlers as a simple test harness
+const func = require('./jobs.js');
+
+func.handler({}, {}, (err, result) => {
+    console.log(err);
+    console.log(result);
+});


### PR DESCRIPTION
Quick fix to replace the import.io API. This uses a lambda function that parses the HTML response from HRM Direct (yeah, I know, regexes are brittle) and converts it into sensible JSON. The careers page now retrieves that instead of hitting import.io.

Note that the lambda function is manually copy/pasted into the AWS Sandbox lamdba account, and was tied to an API Gateway method.